### PR TITLE
Update cap05-part03.md

### DIFF
--- a/cap05-recursao/cap05-part03.md
+++ b/cap05-recursao/cap05-part03.md
@@ -10,8 +10,8 @@ retornar uma lista vazia. O mesmo para números negativos, porque isso não fari
 
 Aqui usamos guards em vez de patterns porque estamos interessados em uma condição booleana. Se 
 [code]n[/code] é menor ou igual a 0, retorna uma lista vazia. Se não, retorna uma lista que tem 
-[code]x[/code] como primeiro elemento e então [code]x[/code] replicado n-1 vezes como a calda 
-(se tratando de listas e algoritmos, a nomenclatura cabeça e calda é bastante usada, acostume-se). 
+[code]x[/code] como primeiro elemento e então [code]x[/code] replicado n-1 vezes como a cauda 
+(se tratando de listas e algoritmos, a nomenclatura cabeça e cauda é bastante usada, acostume-se). 
 Eventualmente, a parte [code](n-1)[/code] fará com que a função chegue à nossa condição limite.
 
 <em>Nota:</em> [code]Num[/code] não é uma subclass de [code]Ord[/code]. Isso significa que o que 
@@ -30,15 +30,15 @@ a lista vazia. Note que estamos usando [code]_[/code] para comparar com a lista 
 interessamos pelo seu valor nesse caso. Note também que nós usamos um guard, mas sem o 
 [code]otherwise[/code]. Isso significa que se [code]n[/code] for maior do que 0, o pattern matching irá 
 para o próximo pattern. O segundo pattern indica que, se tentarmos pegar alguma coisa de uma lista vazia, 
-vamos receber uma lista vazia. O terceiro pattern quebra a lista em uma cabeça e uma calda. E então nós 
+vamos receber uma lista vazia. O terceiro pattern quebra a lista em uma cabeça e uma cauda. E então nós 
 dizemos que pegar [code]n[/code] elementos de uma lista é igual a uma lista que tem [code]x[/code] 
-como a cabeça e então uma outra lista que pega [code]n-1[/code] elementos da calda como calda. Tente usar 
+como a cabeça e então uma outra lista que pega [code]n-1[/code] elementos da cauda como cauda. Tente usar 
 um pedaço de papel para escrever como o algoritmo funcionaria em, digamos, 3 de [code][4,3,2,1][/code].
 
 [code]reverse[/code] simplesmente inverte uma lista. Pense sobre a condição limite. O que ela seria? 
 Vamos lá... é a lista vazia! Uma lista vazia invertida é igual à própria lista vazia. Legal. E o resto? 
-Bem, você poderia dizer que se dividirmos uma lista em cabeça e calda, a lista invertida é igual à 
-calda invertida com a cabeça no final.
+Bem, você poderia dizer que se dividirmos uma lista em cabeça e cauda, a lista invertida é igual à 
+cauda invertida com a cabeça no final.
 
 E aí está pronto.
 
@@ -49,7 +49,7 @@ cortá-las onde quisermos. [code]repeat[/code] pega um elemento e retorna uma li
 apenas aquele elemento. Uma implementação recursiva disso é realmente fácil. Olhe:
 
 Chamar [code]repeat 3[/code] nos dará uma lista que começa com [code]3[/code] e então tem uma 
-quantidade infinita de 3 como calda. Então chamar [code]repeat 3[/code] resuta em algo como 
+quantidade infinita de 3 como cauda. Então chamar [code]repeat 3[/code] resuta em algo como 
 [code]3:repeat 3[/code], que é [code]3:(3:repeat 3)[/code], que é [code]3:(3:(3:repeat 3))[/code]. 
 [code]repeat 3[/code] nunca terminará o pattern matching, enquanto [code]take 5 (repeat 3)[/code] 
 nos retornará uma lista de cinco 3's. Então, essencialmente, é o mesmo que fazer 
@@ -63,7 +63,7 @@ e assim haverá duas condições limite.
 
 Os primeiros dois patterns dizem que se a primeira ou segunda lista é vazia, nós pegamos uma lista 
 vazia. O terceiro diz que a chamada de zip em duas listas é igual a parear as suas cabeças e então 
-continuar a chamar zip nas caldas. A chamada de zip nas listas [code][1,2,3][/code] e 
+continuar a chamar zip nas caudas. A chamada de zip nas listas [code][1,2,3][/code] e 
 [code]['a','b'][/code] eventualmente tentará chamar zip em [code][3][/code] e [code][][/code]. 
 Chega-se então ao padrão da condição limite e assim o resultado é [code](1,'a'):(2,'b'):[][/code], 
 que é exatamente o mesmo que [code][(1,'a'),(2,'b')][/code].
@@ -73,6 +73,6 @@ elemento e uma lista e vê se aquele elemento está na lista. A condição limit
 vezes com listas, é a lista vazia. Nós sabemos que uma lista vazia não contém elemento algum, então 
 temos certeza que ela não tem o que estamos procurando.
 
-Bastante simples e previsível. Se a cabeça não é o elemento, então nós checamos a calda. Se alcançarmos 
+Bastante simples e previsível. Se a cabeça não é o elemento, então nós checamos a cauda. Se alcançarmos 
 uma lista vazia, então o resultado é [code]False[/code].
 


### PR DESCRIPTION
Ajusta palavra **cauda**.

Diferenças de **cauda** e **calda**:

> Estas duas palavras existem na língua portuguesa e estão corretas. Porém, os seus significados são diferentes e devem ser usadas em situações diferentes. O substantivo **cauda** se refere principalmente a um **apêndice posterior**, como o **rabo dos animais**. O substantivo **calda** se refere a um **líquido grosso e doce**, usado na culinária.

Fonte: http://duvidas.dicio.com.br/cauda-ou-calda